### PR TITLE
Fix failing frontend tests by disabling auto-start proxy

### DIFF
--- a/src/tests/shmoxy.frontend.tests/FrontendTestFixture.cs
+++ b/src/tests/shmoxy.frontend.tests/FrontendTestFixture.cs
@@ -32,7 +32,8 @@ public class FrontendTestFixture : IAsyncLifetime
         // Use a dynamic port for the proxy to avoid conflicts with port 8080
         var proxyPort = GetAvailablePort();
         _app = Program.CreateApp(["--urls", BaseUrl, "--contentRoot", apiProjectDir,
-            "--ApiConfig:ProxyPort", proxyPort.ToString()]);
+            "--ApiConfig:ProxyPort", proxyPort.ToString(),
+            "--ApiConfig:AutoStartProxy", "false"]);
 
         // Start the app in the background
         _ = _app.RunAsync();


### PR DESCRIPTION
## Summary
- The `FrontendTestFixture` was not setting `AutoStartProxy=false`, so the proxy auto-started before tests ran
- 5 tests in `ProxyConfigPageTests` failed because they expected initial status "Stopped" but got "Running"
- Added `--ApiConfig:AutoStartProxy false` to the test fixture's `CreateApp` args, matching the pattern used by other test projects (`shmoxy.api.tests`)

## Test plan
- [x] All 12 frontend tests pass (previously 5 failed)
- [x] All 10 shmoxy.tests pass
- [x] All 70 shmoxy.api.tests pass
- [x] `dotnet build` succeeds with zero warnings
- [x] `nix build .#shmoxy` succeeds

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)