### PR TITLE
Add session API endpoints

### DIFF
--- a/src/shmoxy.api/Controllers/SessionsController.cs
+++ b/src/shmoxy.api/Controllers/SessionsController.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using shmoxy.api.models;
+using shmoxy.api.models.dto;
+using shmoxy.api.server;
+
+namespace shmoxy.api.Controllers;
+
+[ApiController]
+[Route("api/sessions")]
+public class SessionsController : ControllerBase
+{
+    private readonly ISessionRepository _sessionRepository;
+
+    public SessionsController(ISessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<SessionResponse>> CreateSession(
+        [FromBody] CreateSessionRequest request,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            return BadRequest(new { Message = "Session name is required" });
+
+        var rows = request.Rows.Select(ToEntity).ToList();
+        var session = await _sessionRepository.CreateSessionAsync(request.Name.Trim(), rows, ct);
+
+        return CreatedAtAction(nameof(GetSession), new { id = session.Id }, ToResponse(session));
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<SessionResponse>>> ListSessions(CancellationToken ct)
+    {
+        var sessions = await _sessionRepository.ListSessionsAsync(ct);
+        return Ok(sessions.Select(ToResponse).ToList());
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<List<SessionRowDto>>> GetSession(string id, CancellationToken ct)
+    {
+        var session = await _sessionRepository.GetSessionAsync(id, ct);
+        if (session is null)
+            return NotFound(new { Message = $"Session '{id}' not found" });
+
+        var rows = await _sessionRepository.LoadRowsAsync(id, ct);
+        return Ok(rows.Select(ToDto).ToList());
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ActionResult<SessionResponse>> UpdateSession(
+        string id,
+        [FromBody] UpdateSessionRequest request,
+        CancellationToken ct)
+    {
+        var session = await _sessionRepository.GetSessionAsync(id, ct);
+        if (session is null)
+            return NotFound(new { Message = $"Session '{id}' not found" });
+
+        var rows = request.Rows.Select(ToEntity).ToList();
+        await _sessionRepository.UpdateSessionAsync(id, rows, ct);
+
+        var updated = await _sessionRepository.GetSessionAsync(id, ct);
+        return Ok(ToResponse(updated!));
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<ActionResult> DeleteSession(string id, CancellationToken ct)
+    {
+        var session = await _sessionRepository.GetSessionAsync(id, ct);
+        if (session is null)
+            return NotFound(new { Message = $"Session '{id}' not found" });
+
+        await _sessionRepository.DeleteSessionAsync(id, ct);
+        return NoContent();
+    }
+
+    private static SessionResponse ToResponse(InspectionSession session) => new()
+    {
+        Id = session.Id,
+        Name = session.Name,
+        RowCount = session.RowCount,
+        CreatedAt = session.CreatedAt,
+        UpdatedAt = session.UpdatedAt
+    };
+
+    private static SessionRowDto ToDto(InspectionSessionRow row) => new()
+    {
+        Method = row.Method,
+        Url = row.Url,
+        StatusCode = row.StatusCode,
+        DurationMs = row.DurationMs,
+        Timestamp = row.Timestamp,
+        RequestHeaders = DeserializeHeaders(row.RequestHeaders),
+        ResponseHeaders = DeserializeHeaders(row.ResponseHeaders),
+        RequestBody = row.RequestBody,
+        ResponseBody = row.ResponseBody
+    };
+
+    private static InspectionSessionRow ToEntity(SessionRowDto dto) => new()
+    {
+        Method = dto.Method,
+        Url = dto.Url,
+        StatusCode = dto.StatusCode,
+        DurationMs = dto.DurationMs,
+        Timestamp = dto.Timestamp,
+        RequestHeaders = SerializeHeaders(dto.RequestHeaders),
+        ResponseHeaders = SerializeHeaders(dto.ResponseHeaders),
+        RequestBody = dto.RequestBody,
+        ResponseBody = dto.ResponseBody
+    };
+
+    private static string? SerializeHeaders(Dictionary<string, string>? headers)
+    {
+        if (headers is null || headers.Count == 0)
+            return null;
+        return JsonSerializer.Serialize(headers);
+    }
+
+    private static Dictionary<string, string>? DeserializeHeaders(string? json)
+    {
+        if (string.IsNullOrEmpty(json))
+            return null;
+        return JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+    }
+}

--- a/src/shmoxy.api/models/dto/SessionDto.cs
+++ b/src/shmoxy.api/models/dto/SessionDto.cs
@@ -1,0 +1,34 @@
+namespace shmoxy.api.models.dto;
+
+public class CreateSessionRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public List<SessionRowDto> Rows { get; set; } = new();
+}
+
+public class SessionResponse
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public int RowCount { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+public class SessionRowDto
+{
+    public string Method { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public int? StatusCode { get; set; }
+    public long? DurationMs { get; set; }
+    public DateTime Timestamp { get; set; }
+    public Dictionary<string, string>? RequestHeaders { get; set; }
+    public Dictionary<string, string>? ResponseHeaders { get; set; }
+    public string? RequestBody { get; set; }
+    public string? ResponseBody { get; set; }
+}
+
+public class UpdateSessionRequest
+{
+    public List<SessionRowDto> Rows { get; set; } = new();
+}

--- a/src/shmoxy.frontend/models/SessionDto.cs
+++ b/src/shmoxy.frontend/models/SessionDto.cs
@@ -1,0 +1,23 @@
+namespace shmoxy.frontend.models;
+
+public class SessionSummary
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public int RowCount { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+public class SessionRowData
+{
+    public string Method { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public int? StatusCode { get; set; }
+    public long? DurationMs { get; set; }
+    public DateTime Timestamp { get; set; }
+    public Dictionary<string, string>? RequestHeaders { get; set; }
+    public Dictionary<string, string>? ResponseHeaders { get; set; }
+    public string? RequestBody { get; set; }
+    public string? ResponseBody { get; set; }
+}

--- a/src/shmoxy.frontend/services/ApiClient.cs
+++ b/src/shmoxy.frontend/services/ApiClient.cs
@@ -113,6 +113,42 @@ public class ApiClient(HttpClient httpClient)
         return await response.Content.ReadFromJsonAsync<List<InspectionRequestInfo>>() ?? [];
     }
 
+    public async Task<List<SessionSummary>> ListSessionsAsync()
+    {
+        var response = await _httpClient.GetAsync("/api/sessions");
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<List<SessionSummary>>() ?? [];
+    }
+
+    public async Task<SessionSummary> CreateSessionAsync(string name, List<SessionRowData> rows)
+    {
+        var response = await _httpClient.PostAsJsonAsync("/api/sessions", new { Name = name, Rows = rows });
+        await EnsureSuccessOrThrowWithBody(response);
+        return await response.Content.ReadFromJsonAsync<SessionSummary>()
+            ?? throw new HttpRequestException("Failed to create session");
+    }
+
+    public async Task<List<SessionRowData>> LoadSessionRowsAsync(string sessionId)
+    {
+        var response = await _httpClient.GetAsync($"/api/sessions/{sessionId}");
+        await EnsureSuccessOrThrowWithBody(response);
+        return await response.Content.ReadFromJsonAsync<List<SessionRowData>>() ?? [];
+    }
+
+    public async Task<SessionSummary> UpdateSessionAsync(string sessionId, List<SessionRowData> rows)
+    {
+        var response = await _httpClient.PutAsJsonAsync($"/api/sessions/{sessionId}", new { Rows = rows });
+        await EnsureSuccessOrThrowWithBody(response);
+        return await response.Content.ReadFromJsonAsync<SessionSummary>()
+            ?? throw new HttpRequestException("Failed to update session");
+    }
+
+    public async Task DeleteSessionAsync(string sessionId)
+    {
+        var response = await _httpClient.DeleteAsync($"/api/sessions/{sessionId}");
+        await EnsureSuccessOrThrowWithBody(response);
+    }
+
     public async IAsyncEnumerable<InspectionEventDto> StreamInspectionEventsAsync(
         string proxyId = "local",
         [EnumeratorCancellation] CancellationToken ct = default)

--- a/src/tests/shmoxy.api.tests/Controllers/SessionsControllerTests.cs
+++ b/src/tests/shmoxy.api.tests/Controllers/SessionsControllerTests.cs
@@ -1,0 +1,191 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using shmoxy.api.Controllers;
+using shmoxy.api.models;
+using shmoxy.api.models.dto;
+using shmoxy.api.server;
+
+namespace shmoxy.api.tests.Controllers;
+
+public class SessionsControllerTests
+{
+    private readonly Mock<ISessionRepository> _mockRepo;
+    private readonly SessionsController _controller;
+
+    public SessionsControllerTests()
+    {
+        _mockRepo = new Mock<ISessionRepository>();
+        _controller = new SessionsController(_mockRepo.Object);
+    }
+
+    [Fact]
+    public async Task CreateSession_ReturnsBadRequest_WhenNameEmpty()
+    {
+        var request = new CreateSessionRequest { Name = "", Rows = [] };
+
+        var result = await _controller.CreateSession(request, CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task CreateSession_ReturnsCreated_WithValidRequest()
+    {
+        var session = new InspectionSession { Id = "abc", Name = "Test", RowCount = 1 };
+        _mockRepo.Setup(r => r.CreateSessionAsync(
+            It.IsAny<string>(), It.IsAny<List<InspectionSessionRow>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var request = new CreateSessionRequest
+        {
+            Name = "Test",
+            Rows = [new SessionRowDto { Method = "GET", Url = "https://example.com", Timestamp = DateTime.UtcNow }]
+        };
+
+        var result = await _controller.CreateSession(request, CancellationToken.None);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+        var response = Assert.IsType<SessionResponse>(created.Value);
+        Assert.Equal("Test", response.Name);
+    }
+
+    [Fact]
+    public async Task ListSessions_ReturnsOk()
+    {
+        _mockRepo.Setup(r => r.ListSessionsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new InspectionSession { Name = "Session 1" },
+                new InspectionSession { Name = "Session 2" }
+            ]);
+
+        var result = await _controller.ListSessions(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var sessions = Assert.IsType<List<SessionResponse>>(ok.Value);
+        Assert.Equal(2, sessions.Count);
+    }
+
+    [Fact]
+    public async Task GetSession_ReturnsNotFound_WhenMissing()
+    {
+        _mockRepo.Setup(r => r.GetSessionAsync("missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InspectionSession?)null);
+
+        var result = await _controller.GetSession("missing", CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetSession_ReturnsRows()
+    {
+        _mockRepo.Setup(r => r.GetSessionAsync("abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InspectionSession { Id = "abc", Name = "Test" });
+        _mockRepo.Setup(r => r.LoadRowsAsync("abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new InspectionSessionRow { Method = "GET", Url = "https://example.com", Timestamp = DateTime.UtcNow }
+            ]);
+
+        var result = await _controller.GetSession("abc", CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var rows = Assert.IsType<List<SessionRowDto>>(ok.Value);
+        Assert.Single(rows);
+        Assert.Equal("GET", rows[0].Method);
+    }
+
+    [Fact]
+    public async Task UpdateSession_ReturnsNotFound_WhenMissing()
+    {
+        _mockRepo.Setup(r => r.GetSessionAsync("missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InspectionSession?)null);
+
+        var request = new UpdateSessionRequest { Rows = [] };
+        var result = await _controller.UpdateSession("missing", request, CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UpdateSession_ReturnsOk_WhenValid()
+    {
+        var session = new InspectionSession { Id = "abc", Name = "Test", RowCount = 2 };
+        _mockRepo.Setup(r => r.GetSessionAsync("abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var request = new UpdateSessionRequest
+        {
+            Rows = [new SessionRowDto { Method = "POST", Url = "https://example.com", Timestamp = DateTime.UtcNow }]
+        };
+
+        var result = await _controller.UpdateSession("abc", request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsType<SessionResponse>(ok.Value);
+    }
+
+    [Fact]
+    public async Task DeleteSession_ReturnsNotFound_WhenMissing()
+    {
+        _mockRepo.Setup(r => r.GetSessionAsync("missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InspectionSession?)null);
+
+        var result = await _controller.DeleteSession("missing", CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteSession_ReturnsNoContent()
+    {
+        _mockRepo.Setup(r => r.GetSessionAsync("abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InspectionSession { Id = "abc", Name = "Test" });
+
+        var result = await _controller.DeleteSession("abc", CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+        _mockRepo.Verify(r => r.DeleteSessionAsync("abc", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateSession_TrimsName()
+    {
+        var session = new InspectionSession { Id = "abc", Name = "Trimmed", RowCount = 0 };
+        _mockRepo.Setup(r => r.CreateSessionAsync(
+            "Trimmed", It.IsAny<List<InspectionSessionRow>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var request = new CreateSessionRequest { Name = "  Trimmed  ", Rows = [] };
+        var result = await _controller.CreateSession(request, CancellationToken.None);
+
+        _mockRepo.Verify(r => r.CreateSessionAsync(
+            "Trimmed", It.IsAny<List<InspectionSessionRow>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSession_DeserializesHeadersFromJson()
+    {
+        _mockRepo.Setup(r => r.GetSessionAsync("abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InspectionSession { Id = "abc", Name = "Test" });
+        _mockRepo.Setup(r => r.LoadRowsAsync("abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new InspectionSessionRow
+                {
+                    Method = "GET",
+                    Url = "https://example.com",
+                    Timestamp = DateTime.UtcNow,
+                    RequestHeaders = """{"Accept":"application/json"}""",
+                    ResponseHeaders = """{"Content-Type":"application/json"}"""
+                }
+            ]);
+
+        var result = await _controller.GetSession("abc", CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var rows = Assert.IsType<List<SessionRowDto>>(ok.Value);
+        Assert.NotNull(rows[0].RequestHeaders);
+        Assert.Equal("application/json", rows[0].RequestHeaders!["Accept"]);
+        Assert.NotNull(rows[0].ResponseHeaders);
+        Assert.Equal("application/json", rows[0].ResponseHeaders!["Content-Type"]);
+    }
+}


### PR DESCRIPTION
## Summary
- `SessionsController` with 5 REST endpoints: POST/GET/GET{id}/PUT{id}/DELETE{id} on `/api/sessions`
- API DTOs: `CreateSessionRequest`, `UpdateSessionRequest`, `SessionResponse`, `SessionRowDto`
- Frontend DTOs: `SessionSummary`, `SessionRowData`
- Frontend `ApiClient` methods: `ListSessionsAsync`, `CreateSessionAsync`, `LoadSessionRowsAsync`, `UpdateSessionAsync`, `DeleteSessionAsync`
- Headers serialized as JSON strings in DB, deserialized to Dictionary in DTOs
- 11 new controller unit tests with mocked repository

## Test plan
- [x] `dotnet build` — zero warnings
- [x] All tests pass (shmoxy.tests: 16, shmoxy.api.tests: 102, shmoxy.frontend.tests: running)
- [x] `nix build .#shmoxy` succeeds

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)