### PR TITLE
Fix inspection response mispairing under concurrent requests

### DIFF
--- a/src/shmoxy.frontend/models/InspectionEventDto.cs
+++ b/src/shmoxy.frontend/models/InspectionEventDto.cs
@@ -7,5 +7,6 @@ public record InspectionEventDto(
     string Url,
     int? StatusCode,
     Dictionary<string, string>? Headers = null,
-    byte[]? Body = null
+    byte[]? Body = null,
+    string? CorrelationId = null
 );

--- a/src/shmoxy.frontend/services/InspectionDataService.cs
+++ b/src/shmoxy.frontend/services/InspectionDataService.cs
@@ -7,7 +7,7 @@ public class InspectionDataService : IDisposable
 {
     private readonly ApiClient _apiClient;
     private readonly List<InspectionRow> _rows = new();
-    private readonly Queue<(int RowIndex, DateTime Timestamp)> _unpairedRequests = new();
+    private readonly Dictionary<string, (int RowIndex, DateTime Timestamp)> _pendingRequests = new();
     private readonly object _lock = new();
 
     private CancellationTokenSource? _cts;
@@ -57,7 +57,7 @@ public class InspectionDataService : IDisposable
         lock (_lock)
         {
             _rows.Clear();
-            _unpairedRequests.Clear();
+            _pendingRequests.Clear();
             _nextId = 1;
         }
         ActiveSessionId = null;
@@ -70,7 +70,7 @@ public class InspectionDataService : IDisposable
         lock (_lock)
         {
             _rows.Clear();
-            _unpairedRequests.Clear();
+            _pendingRequests.Clear();
             _nextId = 1;
 
             foreach (var row in rows)
@@ -108,7 +108,7 @@ public class InspectionDataService : IDisposable
         }
     }
 
-    private void ProcessEvent(InspectionEventDto evt)
+    internal void ProcessEvent(InspectionEventDto evt)
     {
         if (string.Equals(evt.EventType, "request", StringComparison.OrdinalIgnoreCase))
         {
@@ -122,27 +122,35 @@ public class InspectionDataService : IDisposable
                 RequestBody = DecodeBody(evt.Body)
             };
             _rows.Add(row);
-            _unpairedRequests.Enqueue((_rows.Count - 1, evt.Timestamp));
+
+            if (!string.IsNullOrEmpty(evt.CorrelationId))
+            {
+                _pendingRequests[evt.CorrelationId] = (_rows.Count - 1, evt.Timestamp);
+            }
 
             if (_rows.Count > MaxRows)
             {
                 _rows.RemoveAt(0);
-                var adjusted = new Queue<(int, DateTime)>();
-                while (_unpairedRequests.Count > 0)
+                var keysToRemove = new List<string>();
+                var updated = new Dictionary<string, (int, DateTime)>();
+                foreach (var (key, (idx, ts)) in _pendingRequests)
                 {
-                    var (idx, ts) = _unpairedRequests.Dequeue();
                     if (idx > 0)
-                        adjusted.Enqueue((idx - 1, ts));
+                        updated[key] = (idx - 1, ts);
+                    else
+                        keysToRemove.Add(key);
                 }
-                while (adjusted.Count > 0)
-                    _unpairedRequests.Enqueue(adjusted.Dequeue());
+                foreach (var key in keysToRemove)
+                    _pendingRequests.Remove(key);
+                foreach (var (key, value) in updated)
+                    _pendingRequests[key] = value;
             }
         }
         else if (string.Equals(evt.EventType, "response", StringComparison.OrdinalIgnoreCase))
         {
-            if (_unpairedRequests.Count > 0)
+            if (!string.IsNullOrEmpty(evt.CorrelationId) && _pendingRequests.Remove(evt.CorrelationId, out var pending))
             {
-                var (rowIndex, requestTimestamp) = _unpairedRequests.Dequeue();
+                var (rowIndex, requestTimestamp) = pending;
                 if (rowIndex < _rows.Count)
                 {
                     _rows[rowIndex].Duration = evt.Timestamp - requestTimestamp;

--- a/src/shmoxy.frontend/shmoxy.frontend.csproj
+++ b/src/shmoxy.frontend/shmoxy.frontend.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="shmoxy.frontend.tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.0" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.0" />
   </ItemGroup>

--- a/src/shmoxy.shared/ipc/InspectionEvent.cs
+++ b/src/shmoxy.shared/ipc/InspectionEvent.cs
@@ -12,4 +12,5 @@ public record InspectionEvent
     public int? StatusCode { get; init; }
     public Dictionary<string, string> Headers { get; init; } = new();
     public byte[]? Body { get; init; }
+    public string? CorrelationId { get; init; }
 }

--- a/src/shmoxy/models/dto/InterceptedRequest.cs
+++ b/src/shmoxy/models/dto/InterceptedRequest.cs
@@ -17,4 +17,9 @@ public class InterceptedRequest
     /// Gets or sets a value indicating whether to cancel the request.
     /// </summary>
     public bool Cancel { get; set; }
+
+    /// <summary>
+    /// Unique ID linking this request to its corresponding response for inspection.
+    /// </summary>
+    public string? CorrelationId { get; set; }
 }

--- a/src/shmoxy/models/dto/InterceptedResponse.cs
+++ b/src/shmoxy/models/dto/InterceptedResponse.cs
@@ -14,4 +14,9 @@ public class InterceptedResponse
     /// Gets or sets a value indicating whether to cancel/replace the response.
     /// </summary>
     public bool Cancel { get; set; }
+
+    /// <summary>
+    /// Unique ID linking this response to its corresponding request for inspection.
+    /// </summary>
+    public string? CorrelationId { get; set; }
 }

--- a/src/shmoxy/server/ProxyServer.cs
+++ b/src/shmoxy/server/ProxyServer.cs
@@ -340,7 +340,8 @@ public class ProxyServer : IDisposable
                 Port = port,
                 Path = relativePath,
                 Headers = headersDict,
-                Body = body
+                Body = body,
+                CorrelationId = Guid.NewGuid().ToString()
             };
 
             var result = await _interceptor.OnRequestAsync(interceptedRequest);
@@ -550,7 +551,8 @@ public class ProxyServer : IDisposable
             {
                 StatusCode = respStatusCode,
                 Headers = respHeaders,
-                Body = respBody
+                Body = respBody,
+                CorrelationId = request.CorrelationId
             };
             await _interceptor.OnResponseAsync(interceptedResponse);
         }
@@ -616,6 +618,7 @@ public class ProxyServer : IDisposable
             Log(ProxyConfig.LogLevelEnum.Info, $"MITM {method} {scheme}://{host}{path}");
 
             // Intercept request
+            var correlationId = Guid.NewGuid().ToString();
             var interceptedRequest = new InterceptedRequest
             {
                 Method = method,
@@ -624,7 +627,8 @@ public class ProxyServer : IDisposable
                 Port = port,
                 Path = path,
                 Headers = headers,
-                Body = body
+                Body = body,
+                CorrelationId = correlationId
             };
 
             var result = await _interceptor.OnRequestAsync(interceptedRequest);
@@ -717,7 +721,8 @@ public class ProxyServer : IDisposable
                     {
                         StatusCode = respStatusCode,
                         Headers = respHeaders,
-                        Body = respBody
+                        Body = respBody,
+                        CorrelationId = correlationId
                     };
                     await _interceptor.OnResponseAsync(interceptedResponse);
                 }

--- a/src/shmoxy/server/hooks/InspectionHook.cs
+++ b/src/shmoxy/server/hooks/InspectionHook.cs
@@ -43,7 +43,8 @@ public class InspectionHook : IInterceptHook, IDisposable
             Method = request.Method,
             Url = request.Url?.ToString() ?? string.Empty,
             Headers = request.Headers,
-            Body = request.Body
+            Body = request.Body,
+            CorrelationId = request.CorrelationId
         };
 
         _channel.Writer.TryWrite(evt);
@@ -63,7 +64,8 @@ public class InspectionHook : IInterceptHook, IDisposable
             Url = string.Empty,
             StatusCode = response.StatusCode,
             Headers = response.Headers,
-            Body = response.Body
+            Body = response.Body,
+            CorrelationId = response.CorrelationId
         };
 
         _channel.Writer.TryWrite(evt);

--- a/src/tests/shmoxy.frontend.tests/services/InspectionDataServiceTests.cs
+++ b/src/tests/shmoxy.frontend.tests/services/InspectionDataServiceTests.cs
@@ -1,3 +1,4 @@
+using shmoxy.frontend.models;
 using shmoxy.frontend.services;
 using Xunit;
 
@@ -222,5 +223,78 @@ public class InspectionDataServiceTests
         using var service = CreateService();
         Assert.Null(service.ActiveSessionId);
         Assert.Null(service.ActiveSessionName);
+    }
+
+    [Fact]
+    public void ProcessEvent_PairsResponseToRequest_ByCorrelationId()
+    {
+        using var service = CreateService();
+        var now = DateTime.UtcNow;
+
+        service.ProcessEvent(new InspectionEventDto(now, "request", "GET", "https://example.com/1", null, CorrelationId: "corr-1"));
+        service.ProcessEvent(new InspectionEventDto(now.AddMilliseconds(100), "response", "", "", 200, CorrelationId: "corr-1"));
+
+        var rows = service.GetRows();
+        Assert.Single(rows);
+        Assert.Equal("GET", rows[0].Method);
+        Assert.Equal(200, rows[0].StatusCode);
+    }
+
+    [Fact]
+    public void ProcessEvent_PairsOutOfOrderResponses_Correctly()
+    {
+        using var service = CreateService();
+        var now = DateTime.UtcNow;
+
+        // Send 3 requests
+        service.ProcessEvent(new InspectionEventDto(now, "request", "GET", "https://example.com/1", null, CorrelationId: "corr-1"));
+        service.ProcessEvent(new InspectionEventDto(now, "request", "POST", "https://example.com/2", null, CorrelationId: "corr-2"));
+        service.ProcessEvent(new InspectionEventDto(now, "request", "PUT", "https://example.com/3", null, CorrelationId: "corr-3"));
+
+        // Responses arrive out of order: 3, 1, 2
+        service.ProcessEvent(new InspectionEventDto(now.AddMilliseconds(50), "response", "", "", 201, CorrelationId: "corr-3"));
+        service.ProcessEvent(new InspectionEventDto(now.AddMilliseconds(100), "response", "", "", 200, CorrelationId: "corr-1"));
+        service.ProcessEvent(new InspectionEventDto(now.AddMilliseconds(150), "response", "", "", 202, CorrelationId: "corr-2"));
+
+        var rows = service.GetRows();
+        Assert.Equal(3, rows.Count);
+
+        // Each response should be paired with its correct request
+        Assert.Equal("GET", rows[0].Method);
+        Assert.Equal(200, rows[0].StatusCode);
+
+        Assert.Equal("POST", rows[1].Method);
+        Assert.Equal(202, rows[1].StatusCode);
+
+        Assert.Equal("PUT", rows[2].Method);
+        Assert.Equal(201, rows[2].StatusCode);
+    }
+
+    [Fact]
+    public void ProcessEvent_ResponseWithoutCorrelationId_IsIgnored()
+    {
+        using var service = CreateService();
+        var now = DateTime.UtcNow;
+
+        service.ProcessEvent(new InspectionEventDto(now, "request", "GET", "https://example.com", null, CorrelationId: "corr-1"));
+        service.ProcessEvent(new InspectionEventDto(now.AddMilliseconds(100), "response", "", "", 500, CorrelationId: null));
+
+        var rows = service.GetRows();
+        Assert.Single(rows);
+        Assert.Null(rows[0].StatusCode); // Response was not paired
+    }
+
+    [Fact]
+    public void ProcessEvent_ResponseWithUnknownCorrelationId_IsIgnored()
+    {
+        using var service = CreateService();
+        var now = DateTime.UtcNow;
+
+        service.ProcessEvent(new InspectionEventDto(now, "request", "GET", "https://example.com", null, CorrelationId: "corr-1"));
+        service.ProcessEvent(new InspectionEventDto(now.AddMilliseconds(100), "response", "", "", 404, CorrelationId: "corr-unknown"));
+
+        var rows = service.GetRows();
+        Assert.Single(rows);
+        Assert.Null(rows[0].StatusCode); // Response was not paired
     }
 }

--- a/src/tests/shmoxy.tests/server/hooks/InspectionHookTests.cs
+++ b/src/tests/shmoxy.tests/server/hooks/InspectionHookTests.cs
@@ -1,0 +1,93 @@
+using shmoxy.models.dto;
+using shmoxy.server.hooks;
+
+namespace shmoxy.tests.server.hooks;
+
+public class InspectionHookTests
+{
+    [Fact]
+    public async Task OnRequestAsync_IncludesCorrelationId_InEvent()
+    {
+        var hook = new InspectionHook();
+        hook.Enabled = true;
+
+        var request = new InterceptedRequest
+        {
+            Method = "GET",
+            Url = new Uri("https://example.com/test"),
+            CorrelationId = "test-correlation-123"
+        };
+
+        await hook.OnRequestAsync(request);
+
+        var reader = hook.GetReader();
+        Assert.True(reader.TryRead(out var evt));
+        Assert.Equal("request", evt.EventType);
+        Assert.Equal("test-correlation-123", evt.CorrelationId);
+    }
+
+    [Fact]
+    public async Task OnResponseAsync_IncludesCorrelationId_InEvent()
+    {
+        var hook = new InspectionHook();
+        hook.Enabled = true;
+
+        var response = new InterceptedResponse
+        {
+            StatusCode = 200,
+            CorrelationId = "test-correlation-456"
+        };
+
+        await hook.OnResponseAsync(response);
+
+        var reader = hook.GetReader();
+        Assert.True(reader.TryRead(out var evt));
+        Assert.Equal("response", evt.EventType);
+        Assert.Equal("test-correlation-456", evt.CorrelationId);
+    }
+
+    [Fact]
+    public async Task RequestAndResponse_ShareCorrelationId()
+    {
+        var hook = new InspectionHook();
+        hook.Enabled = true;
+
+        var correlationId = Guid.NewGuid().ToString();
+
+        await hook.OnRequestAsync(new InterceptedRequest
+        {
+            Method = "POST",
+            Url = new Uri("https://example.com/api"),
+            CorrelationId = correlationId
+        });
+
+        await hook.OnResponseAsync(new InterceptedResponse
+        {
+            StatusCode = 201,
+            CorrelationId = correlationId
+        });
+
+        var reader = hook.GetReader();
+        Assert.True(reader.TryRead(out var requestEvt));
+        Assert.True(reader.TryRead(out var responseEvt));
+        Assert.Equal(requestEvt.CorrelationId, responseEvt.CorrelationId);
+        Assert.Equal(correlationId, requestEvt.CorrelationId);
+    }
+
+    [Fact]
+    public async Task OnRequestAsync_WhenDisabled_DoesNotWriteEvent()
+    {
+        var hook = new InspectionHook();
+        hook.Enabled = false;
+
+        await hook.OnRequestAsync(new InterceptedRequest
+        {
+            Method = "GET",
+            Url = new Uri("https://example.com"),
+            CorrelationId = "should-not-appear"
+        });
+
+        var reader = hook.GetReader();
+        Assert.False(reader.TryRead(out _));
+    }
+}


### PR DESCRIPTION
## Summary
- Add correlation ID (GUID) to inspection events to correctly pair responses with their originating requests
- Replace FIFO queue pairing in `InspectionDataService` with dictionary-based lookup by correlation ID
- The previous approach assumed responses arrived in the same order as requests, which broke under concurrent load

## Test plan
- [x] `InspectionHookTests` — correlation ID flows through request/response events (4 tests)
- [x] `InspectionDataServiceTests` — out-of-order responses pair correctly by correlation ID (4 tests)
- [x] All existing tests pass (227 tests across all test projects)
- [x] `dotnet build` with zero warnings
- [x] `nix build .#shmoxy` succeeds

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)