### PR TITLE
Fix status panel not respecting dark theme

### DIFF
--- a/src/shmoxy.frontend/layout/MainLayout.razor
+++ b/src/shmoxy.frontend/layout/MainLayout.razor
@@ -2,47 +2,47 @@
 @inject ThemeState ThemeState
 @implements IDisposable
 
-<FluentDesignTheme @ref="_theme" @bind-Mode="_mode" StorageName="preferred-theme" />
+<FluentDesignTheme @ref="_theme" @bind-Mode="_mode" StorageName="preferred-theme">
+    <div class="layout">
+        <header class="header">
+            <div class="header-left">
+                <FluentIcon Value="@(new Icons.Regular.Size24.Globe())" Color="Color.Custom" CustomColor="#7B3FF2" />
+                <span class="header-title">Shmoxy</span>
+            </div>
+            <div class="header-right">
+                <ProxyStatusIndicator />
+                <FluentAnchor Href="/settings" Appearance="Appearance.Stealth" Title="Settings">
+                    <FluentIcon Value="@(new Icons.Regular.Size20.Settings())" />
+                </FluentAnchor>
+            </div>
+        </header>
 
-<div class="layout">
-    <header class="header">
-        <div class="header-left">
-            <FluentIcon Value="@(new Icons.Regular.Size24.Globe())" Color="Color.Custom" CustomColor="#7B3FF2" />
-            <span class="header-title">Shmoxy</span>
+        <div class="body">
+            <nav class="icon-sidebar">
+                <NavLink href="/" Match="NavLinkMatch.All" class="nav-item" title="Inspection">
+                    <FluentIcon Value="@(new Icons.Regular.Size20.DocumentSearch())" />
+                    <span>Inspection</span>
+                </NavLink>
+                <NavLink href="/proxy-config" Match="NavLinkMatch.Prefix" class="nav-item" title="Proxy Config">
+                    <FluentIcon Value="@(new Icons.Regular.Size20.Server())" />
+                    <span>Proxy</span>
+                </NavLink>
+                <NavLink href="/settings" Match="NavLinkMatch.Prefix" class="nav-item" title="Settings">
+                    <FluentIcon Value="@(new Icons.Regular.Size20.Settings())" />
+                    <span>Settings</span>
+                </NavLink>
+            </nav>
+
+            <main class="content">
+                @Body
+            </main>
         </div>
-        <div class="header-right">
-            <ProxyStatusIndicator />
-            <FluentAnchor Href="/settings" Appearance="Appearance.Stealth" Title="Settings">
-                <FluentIcon Value="@(new Icons.Regular.Size20.Settings())" />
-            </FluentAnchor>
-        </div>
-    </header>
-
-    <div class="body">
-        <nav class="icon-sidebar">
-            <NavLink href="/" Match="NavLinkMatch.All" class="nav-item" title="Inspection">
-                <FluentIcon Value="@(new Icons.Regular.Size20.DocumentSearch())" />
-                <span>Inspection</span>
-            </NavLink>
-            <NavLink href="/proxy-config" Match="NavLinkMatch.Prefix" class="nav-item" title="Proxy Config">
-                <FluentIcon Value="@(new Icons.Regular.Size20.Server())" />
-                <span>Proxy</span>
-            </NavLink>
-            <NavLink href="/settings" Match="NavLinkMatch.Prefix" class="nav-item" title="Settings">
-                <FluentIcon Value="@(new Icons.Regular.Size20.Settings())" />
-                <span>Settings</span>
-            </NavLink>
-        </nav>
-
-        <main class="content">
-            @Body
-        </main>
     </div>
-</div>
 
-<FluentToastProvider />
-<FluentDialogProvider />
-<FluentTooltipProvider />
+    <FluentToastProvider />
+    <FluentDialogProvider />
+    <FluentTooltipProvider />
+</FluentDesignTheme>
 
 @code {
     private FluentDesignTheme? _theme;


### PR DESCRIPTION
## Summary
- Wrap layout content with `<FluentDesignTheme>` instead of using it as a self-closing sibling element
- `<FluentCard>` components create their own design system scope and need to be descendants of the theme provider to inherit dark/light mode tokens
- Previously, cards rendered with default white backgrounds even in dark mode

## Test plan
- [x] All tests pass (227 tests across all test projects)
- [x] `dotnet build` with zero warnings
- [x] `nix build .#shmoxy` succeeds
- [ ] Visual verification: open Proxy Config page in dark mode and confirm cards have dark backgrounds

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)