### PR TITLE
Improve API filter to better exclude static resources

### DIFF
--- a/src/shmoxy.frontend/pages/Inspection.razor
+++ b/src/shmoxy.frontend/pages/Inspection.razor
@@ -237,7 +237,7 @@
             .Where(r =>
                 !apiOnlyFilter ||
                 r.StatusCode is null ||
-                ContentTypeClassifier.IsApiResponse(r.ResponseHeaders))
+                ContentTypeClassifier.IsApiCall(r.Url, r.RequestHeaders, r.ResponseHeaders))
             .ToList();
     }
 

--- a/src/shmoxy.frontend/services/ContentTypeClassifier.cs
+++ b/src/shmoxy.frontend/services/ContentTypeClassifier.cs
@@ -2,6 +2,41 @@ namespace shmoxy.frontend.services;
 
 public static class ContentTypeClassifier
 {
+    private static readonly HashSet<string> StaticResourceExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".js", ".mjs", ".cjs",
+        ".css",
+        ".html", ".htm",
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".svg", ".bmp", ".avif",
+        ".woff", ".woff2", ".ttf", ".otf", ".eot",
+        ".wasm",
+        ".map",
+        ".mp3", ".mp4", ".webm", ".ogg", ".wav",
+        ".pdf",
+        ".zip", ".gz", ".br", ".tar", ".bz2",
+    };
+
+    private static readonly HashSet<string> BlobResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "x-ms-blob-type",
+        "x-amz-request-id",
+        "x-goog-stored-content-length",
+    };
+
+    public static bool IsApiCall(string? url, Dictionary<string, string>? requestHeaders, Dictionary<string, string>? responseHeaders)
+    {
+        if (HasStaticResourceExtension(url))
+            return false;
+
+        if (HasBlobStorageHeaders(responseHeaders))
+            return false;
+
+        if (HasFileDownloadDisposition(responseHeaders))
+            return false;
+
+        return IsApiResponse(responseHeaders);
+    }
+
     public static bool IsApiResponse(string? contentType)
     {
         if (string.IsNullOrWhiteSpace(contentType))
@@ -47,5 +82,64 @@ public static class ContentTypeClassifier
         }
 
         return IsApiResponse(contentType);
+    }
+
+    internal static bool HasStaticResourceExtension(string? url)
+    {
+        if (string.IsNullOrEmpty(url))
+            return false;
+
+        // Strip query string and fragment
+        var pathEnd = url.AsSpan();
+        var queryIndex = pathEnd.IndexOf('?');
+        if (queryIndex >= 0)
+            pathEnd = pathEnd[..queryIndex];
+        var fragmentIndex = pathEnd.IndexOf('#');
+        if (fragmentIndex >= 0)
+            pathEnd = pathEnd[..fragmentIndex];
+
+        // Find last dot in the path
+        var lastDot = pathEnd.LastIndexOf('.');
+        if (lastDot < 0)
+            return false;
+
+        // Also ensure the dot is after the last slash (it's a file extension, not part of a hostname)
+        var lastSlash = pathEnd.LastIndexOf('/');
+        if (lastDot < lastSlash)
+            return false;
+
+        var extension = pathEnd[lastDot..].ToString();
+        return StaticResourceExtensions.Contains(extension);
+    }
+
+    private static bool HasBlobStorageHeaders(Dictionary<string, string>? headers)
+    {
+        if (headers is null)
+            return false;
+
+        foreach (var kvp in headers)
+        {
+            if (BlobResponseHeaders.Contains(kvp.Key))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasFileDownloadDisposition(Dictionary<string, string>? headers)
+    {
+        if (headers is null)
+            return false;
+
+        foreach (var kvp in headers)
+        {
+            if (kvp.Key.Equals("Content-Disposition", StringComparison.OrdinalIgnoreCase)
+                && kvp.Value.Contains("attachment", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/tests/shmoxy.frontend.tests/services/ContentTypeClassifierTests.cs
+++ b/src/tests/shmoxy.frontend.tests/services/ContentTypeClassifierTests.cs
@@ -120,4 +120,150 @@ public class ContentTypeClassifierTests
 
         Assert.True(ContentTypeClassifier.IsApiResponse(headers));
     }
+
+    // --- IsApiCall tests ---
+
+    [Theory]
+    [InlineData("https://cdn.example.com/bundle.js")]
+    [InlineData("https://cdn.example.com/app.min.js")]
+    [InlineData("https://cdn.example.com/styles.css")]
+    [InlineData("https://cdn.example.com/logo.png")]
+    [InlineData("https://cdn.example.com/photo.jpg")]
+    [InlineData("https://cdn.example.com/icon.svg")]
+    [InlineData("https://cdn.example.com/font.woff2")]
+    [InlineData("https://cdn.example.com/module.wasm")]
+    [InlineData("https://cdn.example.com/bundle.js.map")]
+    [InlineData("https://cdn.example.com/page.html")]
+    [InlineData("https://cdn.example.com/archive.zip")]
+    [InlineData("https://cdn.example.com/doc.pdf")]
+    public void IsApiCall_ReturnsFalse_ForStaticResourceUrls(string url)
+    {
+        Assert.False(ContentTypeClassifier.IsApiCall(url, null, null));
+    }
+
+    [Theory]
+    [InlineData("https://cdn.example.com/p-5394e5f7.js")]
+    [InlineData("https://cdn.example.com/chunk-abc123.mjs")]
+    public void IsApiCall_ReturnsFalse_ForHashedJsFiles(string url)
+    {
+        Assert.False(ContentTypeClassifier.IsApiCall(url, null, null));
+    }
+
+    [Theory]
+    [InlineData("https://cdn.example.com/bundle.js?v=123")]
+    [InlineData("https://cdn.example.com/styles.css?hash=abc")]
+    [InlineData("https://cdn.example.com/image.png?width=100")]
+    public void IsApiCall_ReturnsFalse_ForStaticResourceUrlsWithQueryString(string url)
+    {
+        Assert.False(ContentTypeClassifier.IsApiCall(url, null, null));
+    }
+
+    [Theory]
+    [InlineData("https://api.example.com/users")]
+    [InlineData("https://api.example.com/v1/data")]
+    [InlineData("https://example.com/api/config")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsApiCall_ReturnsTrue_ForApiUrls(string? url)
+    {
+        Assert.True(ContentTypeClassifier.IsApiCall(url, null, null));
+    }
+
+    [Fact]
+    public void IsApiCall_ReturnsFalse_ForAzureBlobResponse()
+    {
+        var responseHeaders = new Dictionary<string, string>
+        {
+            { "x-ms-blob-type", "BlockBlob" }
+        };
+
+        Assert.False(ContentTypeClassifier.IsApiCall("https://storage.blob.core.windows.net/container/file", null, responseHeaders));
+    }
+
+    [Fact]
+    public void IsApiCall_ReturnsFalse_ForS3Response()
+    {
+        var responseHeaders = new Dictionary<string, string>
+        {
+            { "x-amz-request-id", "ABC123" }
+        };
+
+        Assert.False(ContentTypeClassifier.IsApiCall("https://bucket.s3.amazonaws.com/file", null, responseHeaders));
+    }
+
+    [Fact]
+    public void IsApiCall_ReturnsFalse_ForGcsResponse()
+    {
+        var responseHeaders = new Dictionary<string, string>
+        {
+            { "x-goog-stored-content-length", "12345" }
+        };
+
+        Assert.False(ContentTypeClassifier.IsApiCall("https://storage.googleapis.com/bucket/file", null, responseHeaders));
+    }
+
+    [Fact]
+    public void IsApiCall_ReturnsFalse_ForFileDownloadDisposition()
+    {
+        var responseHeaders = new Dictionary<string, string>
+        {
+            { "Content-Disposition", "attachment; filename=\"report.csv\"" }
+        };
+
+        Assert.False(ContentTypeClassifier.IsApiCall("https://api.example.com/export", null, responseHeaders));
+    }
+
+    [Fact]
+    public void IsApiCall_ReturnsTrue_ForInlineDisposition()
+    {
+        var responseHeaders = new Dictionary<string, string>
+        {
+            { "Content-Disposition", "inline" },
+            { "Content-Type", "application/json" }
+        };
+
+        Assert.True(ContentTypeClassifier.IsApiCall("https://api.example.com/data", null, responseHeaders));
+    }
+
+    [Fact]
+    public void IsApiCall_ReturnsTrue_ForJsonResponseWithNoExtension()
+    {
+        var responseHeaders = new Dictionary<string, string>
+        {
+            { "Content-Type", "application/json" }
+        };
+
+        Assert.True(ContentTypeClassifier.IsApiCall("https://api.example.com/users/123", null, responseHeaders));
+    }
+
+    [Fact]
+    public void IsApiCall_ReturnsFalse_ForJsFileEvenWithMissingContentType()
+    {
+        // This is the exact scenario from the bug report
+        var responseHeaders = new Dictionary<string, string>
+        {
+            { "x-ms-blob-type", "BlockBlob" }
+        };
+
+        Assert.False(ContentTypeClassifier.IsApiCall(
+            "https://platform-cdn.uipath.com/apollo-packages/portal-shell/3.348.5/p-5394e5f7.js",
+            null,
+            responseHeaders));
+    }
+
+    // --- HasStaticResourceExtension tests ---
+
+    [Theory]
+    [InlineData("https://example.com/api/users", false)]
+    [InlineData("https://example.com/file.js", true)]
+    [InlineData("https://example.com/file.JS", true)]
+    [InlineData("https://example.com/path/to/file.css?v=1", true)]
+    [InlineData("https://example.com/path/to/file.png#hash", true)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("https://example.com/path.with.dots/api", false)]
+    public void HasStaticResourceExtension_DetectsCorrectly(string? url, bool expected)
+    {
+        Assert.Equal(expected, ContentTypeClassifier.HasStaticResourceExtension(url));
+    }
 }


### PR DESCRIPTION
## Summary
- Enhance `ContentTypeClassifier` with a new `IsApiCall` method that checks multiple signals beyond just Content-Type
- **URL extension check**: Excludes requests to `.js`, `.css`, `.png`, `.woff2`, `.wasm`, `.map`, `.pdf`, `.zip`, etc.
- **Cloud storage headers**: Excludes responses with `x-ms-blob-type` (Azure), `x-amz-request-id` (S3), `x-goog-stored-content-length` (GCS)
- **Download disposition**: Excludes responses with `Content-Disposition: attachment`
- Falls back to existing Content-Type check for requests without these signals

Fixes the issue where CDN-served files (e.g. `p-5394e5f7.js` from Azure Blob Storage) were shown as API calls because they had no Content-Type header.

## Test plan
- [x] New tests for URL extension detection (12 test cases)
- [x] New tests for blob storage header detection (Azure, S3, GCS)
- [x] New tests for Content-Disposition attachment detection
- [x] Test for the exact reported scenario (UiPath CDN `.js` file with `x-ms-blob-type: BlockBlob`)
- [x] All existing Content-Type classifier tests still pass
- [x] All 264 tests pass across all test projects
- [x] `dotnet build` zero warnings
- [x] `nix build .#shmoxy` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)