### PR TITLE
Fix Blazor reconnect overlay white background in dark theme

### DIFF
--- a/src/shmoxy.frontend/wwwroot/css/app.css
+++ b/src/shmoxy.frontend/wwwroot/css/app.css
@@ -181,3 +181,22 @@ pre {
     white-space: pre-wrap;
     word-break: break-word;
 }
+
+/* Override Blazor Server reconnect dialog to respect theme */
+.components-reconnect-dialog {
+    background-color: var(--neutral-layer-floating, var(--neutral-layer-2));
+    color: var(--neutral-foreground-rest);
+}
+
+.components-reconnect-dialog button {
+    background-color: var(--accent-fill-rest, #6b9ed2);
+    color: var(--foreground-on-accent-rest, white);
+}
+
+.components-reconnect-dialog button:hover {
+    background-color: var(--accent-fill-hover, #3b6ea2);
+}
+
+.components-reconnect-dialog button:active {
+    background-color: var(--accent-fill-active, #6b9ed2);
+}


### PR DESCRIPTION
## Summary
- Override the Blazor Server `.components-reconnect-dialog` styles in `app.css` to use theme-aware CSS variables
- The framework injects `background-color: white` on the reconnect dialog, which is jarring when using dark theme
- Now uses `--neutral-layer-floating` for background and `--neutral-foreground-rest` for text color
- Button styles also updated to use accent fill variables

## Test plan
- [x] All 264 tests pass across all test projects
- [x] `dotnet build` zero warnings
- [x] `nix build .#shmoxy` succeeds
- [ ] Visual verification: disconnect SignalR circuit in dark mode and confirm dialog has dark background

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)