### PR TITLE
Fix detector suggestions never appearing in the UI

### DIFF
--- a/src/shmoxy.api/Controllers/DetectorsController.cs
+++ b/src/shmoxy.api/Controllers/DetectorsController.cs
@@ -77,6 +77,24 @@ public class DetectorsController : ControllerBase
         }
     }
 
+    [HttpGet("suggestions")]
+    public async Task<IActionResult> GetSuggestions(string proxyId, CancellationToken ct)
+    {
+        try
+        {
+            var state = await _processManager.GetStateAsync();
+            if (state?.State != ProxyProcessState.Running)
+                return BadRequest(new { Message = "Proxy must be running" });
+
+            var suggestions = await _processManager.GetIpcClient().GetSuggestionsAsync(ct);
+            return Ok(suggestions);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { Message = ex.Message });
+        }
+    }
+
     [HttpPost("suggestions/accept")]
     public async Task<IActionResult> AcceptSuggestion(
         string proxyId, [FromBody] AcceptSuggestionRequest request, CancellationToken ct)

--- a/src/shmoxy.api/ipc/IProxyIpcClient.cs
+++ b/src/shmoxy.api/ipc/IProxyIpcClient.cs
@@ -24,6 +24,7 @@ public interface IProxyIpcClient
     Task<IReadOnlyList<DetectorDescriptor>> GetDetectorsAsync(CancellationToken ct = default);
     Task EnableDetectorAsync(string id, CancellationToken ct = default);
     Task DisableDetectorAsync(string id, CancellationToken ct = default);
+    Task<IReadOnlyList<PassthroughSuggestion>> GetSuggestionsAsync(CancellationToken ct = default);
     Task AcceptSuggestionAsync(string host, CancellationToken ct = default);
     Task DismissSuggestionAsync(string host, CancellationToken ct = default);
     IAsyncEnumerable<PassthroughSuggestion> GetSuggestionStreamAsync(CancellationToken ct = default);

--- a/src/shmoxy.api/ipc/ProxyIpcClient.cs
+++ b/src/shmoxy.api/ipc/ProxyIpcClient.cs
@@ -223,6 +223,17 @@ public class ProxyIpcClient : IProxyIpcClient, IDisposable
         }, ct);
     }
 
+    public async Task<IReadOnlyList<PassthroughSuggestion>> GetSuggestionsAsync(CancellationToken ct = default)
+    {
+        return await RetryAsync(async () =>
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(IpcTimeouts.Medium);
+            return await _httpClient.GetFromJsonAsync<IReadOnlyList<PassthroughSuggestion>>("/ipc/detectors/suggestions", _jsonOptions, cts.Token)
+                ?? Array.Empty<PassthroughSuggestion>();
+        }, ct);
+    }
+
     public async Task AcceptSuggestionAsync(string host, CancellationToken ct = default)
     {
         await RetryAsync(async () =>

--- a/src/shmoxy.frontend/pages/ProxyConfig.razor
+++ b/src/shmoxy.frontend/pages/ProxyConfig.razor
@@ -246,6 +246,7 @@
         {
             detectors = await ApiClient.GetDetectorsAsync();
             detectorStates = detectors.ToDictionary(d => d.Id, d => d.Enabled);
+            suggestions = await ApiClient.GetSuggestionsAsync();
         }
         catch
         {

--- a/src/shmoxy.frontend/services/ApiClient.cs
+++ b/src/shmoxy.frontend/services/ApiClient.cs
@@ -124,6 +124,15 @@ public class ApiClient(HttpClient httpClient)
         await EnsureSuccessOrThrowWithBody(response);
     }
 
+    public async Task<List<PassthroughSuggestionDto>> GetSuggestionsAsync()
+    {
+        var response = await _httpClient.GetAsync("/api/proxies/local/detectors/suggestions");
+        if (!response.IsSuccessStatusCode)
+            return [];
+
+        return await response.Content.ReadFromJsonAsync<List<PassthroughSuggestionDto>>() ?? [];
+    }
+
     public async Task AcceptSuggestionAsync(string host)
     {
         var response = await _httpClient.PostAsJsonAsync("/api/proxies/local/detectors/suggestions/accept", new { Host = host });

--- a/src/shmoxy/ipc/ProxyControlApi.cs
+++ b/src/shmoxy/ipc/ProxyControlApi.cs
@@ -211,6 +211,14 @@ public static class ProxyControlApi
             return Results.Json(new { Success = success, Message = success ? "Detector disabled" : $"Unknown detector: {id}" });
         });
 
+        endpoints.MapGet("/ipc/detectors/suggestions", () =>
+        {
+            if (stateService.DetectorHook == null)
+                return Results.Json(Array.Empty<PassthroughSuggestion>());
+
+            return Results.Json(stateService.DetectorHook.GetSuggestions());
+        });
+
         endpoints.MapGet("/ipc/detectors/suggestions/stream", async (HttpResponse response) =>
         {
             if (stateService.DetectorHook == null)

--- a/src/shmoxy/server/hooks/PassthroughDetectorHook.cs
+++ b/src/shmoxy/server/hooks/PassthroughDetectorHook.cs
@@ -16,6 +16,7 @@ public class PassthroughDetectorHook : IInterceptHook, IDisposable
     private readonly Dictionary<string, bool> _enabledDetectors = new();
     private readonly ConcurrentDictionary<string, InterceptedRequest> _pendingRequests = new();
     private readonly Channel<PassthroughSuggestion> _suggestions;
+    private readonly List<PassthroughSuggestion> _activeSuggestions = new();
     private readonly HashSet<string> _dismissedHosts = new();
     private readonly HashSet<string> _suggestedHosts = new();
     private readonly object _lock = new();
@@ -81,12 +82,24 @@ public class PassthroughDetectorHook : IInterceptHook, IDisposable
     /// <summary>
     /// Dismisses a suggestion so it won't resurface.
     /// </summary>
+    /// <summary>
+    /// Gets all active (non-dismissed) suggestions.
+    /// </summary>
+    public IReadOnlyList<PassthroughSuggestion> GetSuggestions()
+    {
+        lock (_lock)
+        {
+            return _activeSuggestions.ToList();
+        }
+    }
+
     public void DismissSuggestion(string host)
     {
         lock (_lock)
         {
             _dismissedHosts.Add(host);
             _suggestedHosts.Remove(host);
+            _activeSuggestions.RemoveAll(s => s.Host == host);
         }
     }
 
@@ -173,6 +186,11 @@ public class PassthroughDetectorHook : IInterceptHook, IDisposable
             DetectorName = result.DetectorName,
             Reason = result.Reason
         };
+
+        lock (_lock)
+        {
+            _activeSuggestions.Add(suggestion);
+        }
 
         _suggestions.Writer.TryWrite(suggestion);
     }


### PR DESCRIPTION
## Summary
- Suggestions were written to a fire-and-forget Channel but never stored — the frontend had no way to retrieve them, so the suggestions list was always empty
- Added `GetSuggestions()` to `PassthroughDetectorHook` backed by `_activeSuggestions` list
- Added `GET /ipc/detectors/suggestions` endpoint + API controller + frontend wiring
- Frontend now loads suggestions on page init alongside detectors

## Test plan
- [x] `dotnet build` zero warnings
- [x] shmoxy.tests: 57 passed, shmoxy.api.tests: 109 passed
- [ ] Manual: enable detectors, browse a Cloudflare-blocked site, verify suggestion appears on ProxyConfig page

🤖 Generated with [Claude Code](https://claude.com/claude-code)